### PR TITLE
fixed link to twitchplayspokemon.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
 	
 	<br>
 
-	<h3 style="text-align:center; padding-top:3%; color:goldenrod;">Courtesy of <a href="www.twitchplayspokemon.org">twitchplayspokemon.org</a>.</h3>
+	<h3 style="text-align:center; padding-top:3%; color:goldenrod;">Courtesy of <a href="http://www.twitchplayspokemon.org">twitchplayspokemon.org</a>.</h3>
 
 	<div class="large-12 columns" align="center">
     	<iframe id="ifr" frameborder="0" width="1200" height="500" src="http://www.twitchplayspokemon.org/"></iframe>


### PR DESCRIPTION
Current link leads to 'http://twitchplayspokemon.net/www.twitchplayspokemon.org' which is a broken link.
